### PR TITLE
deps: dump zeebe from 8.1.8 to 8.2.0-alpha4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
     <name>Zeebe Hazelcast Root</name>
@@ -11,12 +12,12 @@
         <groupId>org.camunda.community</groupId>
         <artifactId>community-hub-release-parent</artifactId>
         <version>1.4.1</version>
-        <relativePath />
+        <relativePath/>
     </parent>
 
     <properties>
-        <version.zeebe>8.1.8</version.zeebe>
-        <version.exporter.protobuf>1.3.0</version.exporter.protobuf>
+        <version.zeebe>8.2.0-alpha4</version.zeebe>
+        <version.exporter.protobuf>1.4.0-alpha1</version.exporter.protobuf>
         <version.hazelcast>5.2.2</version.hazelcast>
         <version.log4j>2.20.0</version.log4j>
         <version.zeebe.testcontainers>3.5.2</version.zeebe.testcontainers>


### PR DESCRIPTION
## Description

- dump `zeebe` from `8.1.8` to `8.2.0-alpha4`
- dump `zeebe-exporter-protobuf` from `1.3.0` to `1.4.0-alpha1` (depends on `8.2.0-alpha4`)